### PR TITLE
@ManyToOne_@OneToOne_수정_Article_Answer_like_likes로_수정

### DIFF
--- a/src/main/java/devcom/main/domain/answer/entity/Answer.java
+++ b/src/main/java/devcom/main/domain/answer/entity/Answer.java
@@ -1,11 +1,15 @@
 package devcom.main.domain.answer.entity;
 
+
 import devcom.main.domain.article.entity.Article;
-import devcom.main.domain.reply.entity.Reply;
 import devcom.main.global.jpa.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,12 +23,13 @@ import lombok.experimental.SuperBuilder;
 public class Answer extends BaseEntity {
 
     private String content;
-
-    private int like;
+    @Column
+    private Integer likes;
 
     @ManyToOne
+    @JoinColumn
     private Article originalArticle;
-
-    @OneToMany
-    private Reply reply;
+//
+//    @OneToMany
+//    private Reply reply;
 }

--- a/src/main/java/devcom/main/domain/article/entity/Article.java
+++ b/src/main/java/devcom/main/domain/article/entity/Article.java
@@ -4,10 +4,9 @@ import devcom.main.domain.category.entity.Category;
 import devcom.main.domain.img.entity.Img;
 import devcom.main.domain.user.entity.SiteUser;
 import devcom.main.global.jpa.BaseEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,17 +27,18 @@ public class Article extends BaseEntity {
     private String content;
 
     // 조회수
-    private int hit;
+    @Column
+    private Integer hit;
 
     // 좋아요
-    private int like;
+    @Column
+    private Integer likes;
 
     @OneToOne
+    @JoinColumn
     private Category category;
 
-    @OneToMany
-    private Img img_url;
-
     @ManyToOne
+    @JoinColumn(name = "author_id")
     private SiteUser author;
 }

--- a/src/main/java/devcom/main/domain/category/entity/Category.java
+++ b/src/main/java/devcom/main/domain/category/entity/Category.java
@@ -17,4 +17,5 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 public class Category extends BaseEntity {
     private String categoryName;
+
 }

--- a/src/main/java/devcom/main/domain/img/entity/Img.java
+++ b/src/main/java/devcom/main/domain/img/entity/Img.java
@@ -1,5 +1,6 @@
 package devcom.main.domain.img.entity;
 
+import devcom.main.domain.answer.entity.Answer;
 import devcom.main.domain.article.entity.Article;
 import devcom.main.global.jpa.BaseEntity;
 import jakarta.persistence.*;
@@ -17,4 +18,7 @@ public class Img extends BaseEntity {
 
     private String img_url;
 
+    @ManyToOne
+    @JoinColumn
+    private Article originalArticle;
 }

--- a/src/main/java/devcom/main/domain/reply/entity/Reply.java
+++ b/src/main/java/devcom/main/domain/reply/entity/Reply.java
@@ -1,7 +1,11 @@
 package devcom.main.domain.reply.entity;
 
+import devcom.main.domain.answer.entity.Answer;
+import devcom.main.domain.article.entity.Article;
 import devcom.main.global.jpa.BaseEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,4 +18,8 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 public class Reply extends BaseEntity {
     private String content;
+
+    @ManyToOne
+    @JoinColumn
+    private Answer originalAnswer;
 }

--- a/src/test/java/devcom/main/MainApplicationTests.java
+++ b/src/test/java/devcom/main/MainApplicationTests.java
@@ -1,15 +1,19 @@
 package devcom.main;
 
+import devcom.main.domain.article.service.ArticleService;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class MainApplicationTests {
 
+	@Autowired
+	ArticleService articleService;
 
 	@Test
 	void contextLoads() {
-
+		this.articleService.create("s1", "c1");
 	}
 
 }


### PR DESCRIPTION
## 문제
- Article 과 Answer 엔티티의 'like' Column이 SQL예약어라서 sql문이 전송되지 않았음
- 연관관계 애너테이션이 난잡하게 적혀있었음

## 문제 해결 방법
[JPA @OneToMany, @ManyToOne으로 연관관계 관리하기](https://velog.io/@goniieee/JPA-OneToMany-ManyToOne%EC%9C%BC%EB%A1%9C-%EC%97%B0%EA%B4%80%EA%B4%80%EA%B3%84-%EA%B4%80%EB%A6%AC%ED%95%98%EA%B8%B0)
위 블로그를 보고 해결하였습니다.
위 블로그에서 소개한 @ ManyToOne 단방향 연관관계 방식을 따랐습니다.

- 'like' 칼럼 이름 수정 => 'likes'
- @ ManyToOne 단방향 연관관계 설정 방식으로 코드 작성.
- @ OneToOne 은 Category 엔티티의 외래키가 Article에 있어야 하므로 Article에 OneToOne 애너테이션 작성.

## 보고
- 잘 작동하고 DB에 엔티티 생성 잘 됩니다.